### PR TITLE
refactor: centralize llm usage and add agent base

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class Agent(ABC):
+    """Base Agent template defining the run interface."""
+
+    @abstractmethod
+    def run(self, payload: Any, context: Dict[str, Any]):
+        """Execute the agent with provided payload and context."""
+        raise NotImplementedError

--- a/services/llm_service.py
+++ b/services/llm_service.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Any, Dict, List
+
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+
+class LLMService:
+    """Central service for invoking LLM models and logging usage."""
+
+    _client: OpenAI | None = None
+
+    @classmethod
+    def _get_client(cls) -> OpenAI:
+        if cls._client is None:
+            cls._client = OpenAI()
+        return cls._client
+
+    @classmethod
+    def invoke(cls, model: str, messages: List[Dict[str, str]], **opts: Any):
+        client = cls._get_client()
+        response = client.chat.completions.create(model=model, messages=messages, **opts)
+        usage = getattr(response, "usage", None)
+        if usage:
+            logger.info(
+                "LLM usage - prompt: %s, completion: %s, total: %s",
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                usage.total_tokens,
+            )
+        return response


### PR DESCRIPTION
## Summary
- introduce `LLMService` for unified OpenAI access and usage logging
- add reusable `Agent` base class with `run` interface
- refactor core agents to subclass `Agent` and call `LLMService`

## Testing
- `PYTHONPATH=. pytest` *(fails: Chrome missing for plotly export; missing `bookings` table)*

------
https://chatgpt.com/codex/tasks/task_e_68a54ddda0688331993b1c8528cd61f0