### PR TITLE
Add fine-tuning pipeline and model registry

### DIFF
--- a/learning/fine_tune.py
+++ b/learning/fine_tune.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class TrainingExample:
+    """Represents a single training example consisting of a prompt/completion pair."""
+
+    prompt: str
+    completion: str
+
+    @classmethod
+    def from_jsonl(cls, path: str | Path) -> List["TrainingExample"]:
+        """Load a list of :class:`TrainingExample` from a JSONL file.
+
+        Each line in ``path`` must be a JSON object with ``prompt`` and ``completion``
+        fields.  Empty lines are ignored.
+        """
+
+        path = Path(path)
+        examples: List[TrainingExample] = []
+        with path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                examples.append(cls(prompt=data["prompt"], completion=data["completion"]))
+        return examples
+
+
+def _build_dataset(examples: List[TrainingExample]):
+    """Convert examples into a HuggingFace ``Dataset`` object.
+
+    The dataset contains a single ``text`` column with the prompt and completion
+    concatenated.  The exact formatting can be adjusted depending on the target
+    model.  Here we separate prompt and completion with a newline.
+    """
+
+    from datasets import Dataset  # Lazy import to avoid heavy dependency at import time
+
+    records = [{"text": f"{ex.prompt}\n{ex.completion}"} for ex in examples]
+    return Dataset.from_list(records)
+
+
+def fine_tune(
+    base_model: str,
+    train_path: str | Path,
+    output_dir: str | Path,
+    validation_path: str | Path | None = None,
+) -> str:
+    """Fine‑tune ``base_model`` using Unsloth/HuggingFace tooling.
+
+    Parameters
+    ----------
+    base_model:
+        Name of the base model to fine‑tune (e.g., ``"google/gemma-2b"``).
+    train_path:
+        Path to a JSONL file containing training examples.
+    output_dir:
+        Directory where the fine‑tuned model will be saved.
+    validation_path:
+        Optional path to validation examples; if provided the trainer will
+        evaluate during training.
+
+    Returns
+    -------
+    str
+        The path to the directory containing the fine‑tuned model.
+    """
+
+    examples = TrainingExample.from_jsonl(train_path)
+    train_dataset = _build_dataset(examples)
+
+    eval_dataset = None
+    if validation_path:
+        eval_dataset = _build_dataset(TrainingExample.from_jsonl(validation_path))
+
+    # Import Unsloth and HuggingFace components lazily to avoid imposing a
+    # heavy dependency when this module is imported but training is not run.
+    from unsloth import FastLanguageModel
+
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        base_model,
+        load_in_4bit=True,
+    )
+
+    model = FastLanguageModel.get_peft_model(model)
+
+    trainer = model.get_trainer(
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        tokenizer=tokenizer,
+        output_dir=str(output_dir),
+    )
+    trainer.train()
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    return str(output_dir)
+
+
+def evaluate_model(model_path: str | Path, validation_path: str | Path) -> Dict[str, float]:
+    """Evaluate a fine‑tuned model on a validation set.
+
+    The evaluation performed here is intentionally lightweight and is meant to
+    provide a quick sanity check rather than a rigorous benchmark.  It computes
+    the fraction of validation examples for which the model's output contains
+    the expected completion string.
+    """
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+
+    examples = TrainingExample.from_jsonl(validation_path)
+    if not examples:
+        return {"accuracy": 0.0}
+
+    model = AutoModelForCausalLM.from_pretrained(model_path)
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+
+    correct = 0
+    for ex in examples:
+        inputs = tokenizer(ex.prompt, return_tensors="pt").to(device)
+        output_ids = model.generate(**inputs, max_new_tokens=64)
+        text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+        if ex.completion.strip() in text:
+            correct += 1
+
+    accuracy = correct / len(examples)
+    return {"accuracy": accuracy}

--- a/scripts/fine_tune.py
+++ b/scripts/fine_tune.py
@@ -1,0 +1,65 @@
+"""Command line interface for fine‑tuning models.
+
+This script orchestrates loading training data, running the fine‑tuning
+process, evaluating the resulting model, and registering it so that the rest
+of the application can discover and use it.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from learning.fine_tune import evaluate_model, fine_tune
+from services import model_registry
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fine‑tune a language model")
+    parser.add_argument(
+        "--train",
+        default="training_examples.jsonl",
+        help="Path to training data in JSONL format",
+    )
+    parser.add_argument(
+        "--validation",
+        default=None,
+        help="Optional path to validation data in JSONL format",
+    )
+    parser.add_argument(
+        "--base-model",
+        default="google/gemma-2b",
+        help="Name of the base model to fine‑tune",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="fine_tuned_models",
+        help="Directory where the fine‑tuned model will be saved",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    output_dir = fine_tune(
+        base_model=args.base_model,
+        train_path=args.train,
+        output_dir=args.output_dir,
+        validation_path=args.validation,
+    )
+
+    metrics = None
+    if args.validation:
+        metrics = evaluate_model(output_dir, args.validation)
+
+    model_registry.register_model(
+        base_model=args.base_model,
+        model_path=output_dir,
+        metrics=metrics,
+    )
+
+    print(f"Model saved to {output_dir} and registered.")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/services/llm_service.py
+++ b/services/llm_service.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List
 
 from openai import OpenAI
 
+from .model_registry import get_latest_model
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,8 +21,18 @@ class LLMService:
 
     @classmethod
     def invoke(cls, model: str, messages: List[Dict[str, str]], **opts: Any):
+        """Invoke a chat completion model.
+
+        If a fine‑tuned variant of ``model`` has been registered via the
+        :mod:`services.model_registry`, it will be used instead of the base model.
+        """
+
+        target_model = get_latest_model(model) or model
+
         client = cls._get_client()
-        response = client.chat.completions.create(model=model, messages=messages, **opts)
+        response = client.chat.completions.create(
+            model=target_model, messages=messages, **opts
+        )
         usage = getattr(response, "usage", None)
         if usage:
             logger.info(

--- a/services/model_registry.py
+++ b/services/model_registry.py
@@ -1,0 +1,49 @@
+"""Simple on-disk registry for fine‑tuned models."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+_REGISTRY_PATH = Path(__file__).with_name("model_registry.json")
+
+
+def _read_registry() -> List[Dict]:
+    if _REGISTRY_PATH.exists():
+        return json.loads(_REGISTRY_PATH.read_text())
+    return []
+
+
+def _write_registry(entries: List[Dict]) -> None:
+    _REGISTRY_PATH.write_text(json.dumps(entries, indent=2))
+
+
+def register_model(base_model: str, model_path: str, metrics: Optional[Dict] = None) -> Dict:
+    """Record a newly fine‑tuned model in the registry."""
+
+    entries = _read_registry()
+    entry = {
+        "base_model": base_model,
+        "model_path": model_path,
+        "metrics": metrics or {},
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    entries.append(entry)
+    _write_registry(entries)
+    return entry
+
+
+def get_latest_model(base_model: str) -> Optional[str]:
+    """Return the most recently registered model for ``base_model``.
+
+    If no fine‑tuned models have been registered, ``None`` is returned.
+    """
+
+    entries = [e for e in _read_registry() if e["base_model"] == base_model]
+    if not entries:
+        return None
+    latest = max(entries, key=lambda e: e["timestamp"])
+    return latest["model_path"]

--- a/training_examples.jsonl
+++ b/training_examples.jsonl
@@ -1,0 +1,2 @@
+{"prompt": "Hello", "completion": "Hi there!"}
+{"prompt": "What is 2+2?", "completion": "4"}


### PR DESCRIPTION
## Summary
- add `learning.fine_tune` to train and evaluate models via Unsloth/HuggingFace
- provide `scripts/fine_tune.py` CLI for launching training and registering models
- introduce simple on-disk model registry and update `LLMService` to use latest fine-tuned models

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a58a9c2f1883319ac3548d6b08e8b8