### PR TITLE
feat: centralize SQL validation and repair

### DIFF
--- a/agents/reasoning_agent/agent.py
+++ b/agents/reasoning_agent/agent.py
@@ -8,7 +8,7 @@ from typing import Optional, List, Dict, Any
 from pydantic import BaseModel
 from agents.visualization.agent import VisualizationAgent, VisualizationOptions
 from agents.base import Agent
-from services.llm_service import LLMService
+from services.validation_engine import ValidationEngine
 
 class ExecutionPlan:
     """Tracks current SQL, retries, errors, and optional visualization options."""
@@ -41,6 +41,7 @@ class ReasoningAgent(Agent):
         if hasattr(self.executor, "set_error_handler"):
             self.executor.set_error_handler(self.handle_execution_error)
         self.viz_agent = VisualizationAgent()
+        self.validation_engine = ValidationEngine()
         self.current_plan: Optional[ExecutionPlan] = None
 
     def run(self, payload: str, context: str):
@@ -100,8 +101,8 @@ class ReasoningAgent(Agent):
 
                 # 5) Classify & repair
                 err_msg = str(e)
-                err_type = self._classify_error(err_msg)
-                repaired_sql = self._repair_sql(last_sql, schema_context, err_type, err_msg)
+                err_type = self.validation_engine._classify_error(err_msg)
+                repaired_sql = self.validation_engine.repair(last_sql, err_msg, schema_context)
                 if repaired_sql and repaired_sql.strip() != last_sql.strip():
                     # Optional: log for guideline mining
                     self._log_guideline_case(
@@ -145,95 +146,6 @@ class ReasoningAgent(Agent):
             return self._ensure_terminated(s), False
         return self._ensure_terminated(s + " LIMIT 1"), True
 
-    def _classify_error(self, msg: str) -> str:
-        m = msg.lower()
-        if "no such table" in m or "no such column" in m:
-            return "schema"
-        if "syntax error" in m:
-            return "syntax"
-        if "misuse of aggregate" in m or "group by" in m:
-            return "aggregate"
-        if "ambiguous column" in m:
-            return "ambiguous"
-        return "semantic"
-
-    def _repair_sql(self, sql: str, schema_context: str, err_type: str, error_msg: str) -> Optional[str]:
-        """
-        Use schema-aware, targeted prompts to fix SQL. Keep the original intent.
-        Returns ONE corrected SQLite query string or None.
-        """
-        try:
-            from utils.token_tracker import record_openai_usage_from_response
-        except Exception:
-            return None
-
-        system = {
-            "role": "system",
-            "content": "You are a SQL fixer. Return ONE corrected SQLite query only. No markdown, no explanations."
-        }
-        user = {"role": "user", "content": self._prompt_for(err_type, schema_context, sql, error_msg)}
-
-        try:
-            r = LLMService.invoke(
-                model="gpt-3.5-turbo",
-                messages=[system, user],
-                temperature=0.0,
-                max_tokens=400,
-            )
-            # Record token usage
-            record_openai_usage_from_response(r)
-            fixed = r.choices[0].message.content.strip()
-            # Simple guard: ensure it looks like SQL
-            if re.match(r"^\s*(select|with|update|delete|insert)\b", fixed, flags=re.I):
-                return fixed
-            return None
-        except Exception:
-            return None
-
-    def _prompt_for(self, err_type: str, schema_context: str, sql: str, error_msg: str) -> str:
-        common = f"""Schema:
-{schema_context}
-
-Previous SQL:
-{sql}
-
-Error:
-{error_msg}
-"""
-        if err_type == "schema":
-            checklist = (
-                "- Use only tables/columns present in the Schema.\n"
-                "- If a column is missing, pick the closest semantically relevant existing column.\n"
-                "- Preserve the original intent: keep aggregates, filters, and grouping.\n"
-            )
-        elif err_type == "aggregate":
-            checklist = (
-                "- If SELECT mixes aggregates and non-aggregates, add GROUP BY for all non-aggregated columns.\n"
-                "- Apply SUM/AVG/COUNT only to numeric columns.\n"
-            )
-        elif err_type == "ambiguous":
-            checklist = (
-                "- Qualify columns with table aliases.\n"
-                "- Join only on identically named key columns (e.g., *_id) that exist in both tables.\n"
-            )
-        elif err_type == "syntax":
-            checklist = (
-                "- Fix SQL syntax without changing intent.\n"
-                "- Ensure correct order/placement of WHERE, GROUP BY, ORDER BY, LIMIT.\n"
-            )
-        else:  # semantic/other
-            checklist = (
-                "- For top-N, ensure ORDER BY a metric DESC and include LIMIT N.\n"
-                "- If empty results, relax strict equality to LIKE or >= where reasonable.\n"
-                "- If too many rows, add LIMIT 100 with ORDER BY a sensible metric.\n"
-            )
-
-        return f"""{common}
-Fix the SQL using the checklist:
-
-Checklist:
-{checklist}
-Return only ONE corrected SQLite query (no markdown, no prose)."""
 
     def _needs_semantic_adjustment(self, sql: str, result) -> bool:
         """

--- a/agents/sql_generator/__init__.py
+++ b/agents/sql_generator/__init__.py
@@ -1,3 +1,3 @@
-from .agent import SQLGeneratorAgent
+"""SQL generator agents package."""
 
-__all__ = ['SQLGeneratorAgent'] 
+__all__ = []

--- a/agents/sql_generator/agent.py
+++ b/agents/sql_generator/agent.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 from .schemas import SQLQuery, SQLGenerationRequest
 from .few_shot_generator import FewShotExampleGenerator
 from .planner import SQLPlannerAgent
-from .validator import SQLValidatorAgent
+from services.validation_engine import ValidationEngine
 from utils.token_tracker import record_openai_usage_from_response
 
 from dotenv import load_dotenv
@@ -57,7 +57,7 @@ class SQLGeneratorAgent(Agent):
         self.model = "gpt-3.5-turbo"
         self.few_shot_generator = FewShotExampleGenerator()
         self.planner = SQLPlannerAgent(api_key)
-        self.validator = SQLValidatorAgent()
+        self.validation_engine = ValidationEngine()
         logger.info("SQLGeneratorAgent initialized with Planner → Validator → Generator flow")
     
     def generate_sql(self, intent_data: dict, schema_info: dict) -> SQLQuery:
@@ -81,7 +81,7 @@ class SQLGeneratorAgent(Agent):
             
             # Step 2: VALIDATOR - Validate and normalize the plan
             logger.info("Step 2: Validating and normalizing plan...")
-            normalized_plan, validation_report = self.validator.validate_plan(plan_dict, schema_info)
+            normalized_plan, validation_report = self.validation_engine.validate(plan_dict, schema_info)
             
             # Check validation results
             if not validation_report.ok:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -22,7 +22,7 @@ step.  Example YAML::
       planner:
         class: agents.sql_generator.planner.SQLPlannerAgent
       validator:
-        class: agents.sql_generator.validator.SQLValidatorAgent
+        class: services.validation_engine.ValidationEngine
       sql_generator:
         class: agents.sql_generator.agent.SQLGeneratorAgent
       executor:
@@ -158,7 +158,7 @@ class Orchestrator:
         schema = self.schema_retriever.get_schema()
         intent = self.intent_parser.parse(question, schema)
         plan = self.planner.create_plan(intent, schema)
-        normalized_plan, _report = self.validator.validate_plan(plan, schema)
+        normalized_plan, _report = self.validator.validate(plan, schema)
         sql_query = self.sql_generator.generate_sql(normalized_plan, schema)
         result = self.executor.execute(sql_query.sql)
 

--- a/core/workflow.yaml
+++ b/core/workflow.yaml
@@ -10,7 +10,7 @@ steps:
     class: agents.sql_generator.planner.SQLPlannerAgent
     params: {}
   validator:
-    class: agents.sql_generator.validator.SQLValidatorAgent
+    class: services.validation_engine.ValidationEngine
     params: {}
   sql_generator:
     class: agents.sql_generator.agent.SQLGeneratorAgent

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 # main.py
 from agents.workflow import SQLWorkflow
-from agents.sql_generator import SQLGeneratorAgent
+from agents.sql_generator.agent import SQLGeneratorAgent
 import sqlite3
 import json
 from dotenv import load_dotenv

--- a/services/validation_engine.py
+++ b/services/validation_engine.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""Central validation and repair service used across agents.
+
+This module provides a `ValidationEngine` that wraps the existing
+`SQLValidatorAgent` and the SQL repair logic previously embedded in
+`ReasoningAgent._repair_sql`.  Agents should import and use this service for
+plan validation and SQL error repair instead of implementing their own logic.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+import re
+
+from agents.sql_generator.validator import SQLValidatorAgent
+from services.llm_service import LLMService
+
+try:  # optional dependency used for accounting
+    from utils.token_tracker import record_openai_usage_from_response
+except Exception:  # pragma: no cover - best effort
+    record_openai_usage_from_response = lambda _resp: None
+
+
+class ValidationEngine:
+    """Wrapper around SQL plan validation and SQL repair helpers."""
+
+    def __init__(self):
+        self._validator = SQLValidatorAgent()
+
+    # ------------------------------------------------------------------
+    # Plan validation
+    # ------------------------------------------------------------------
+    def validate(self, plan: Dict[str, Any], schema: Dict[str, Any]) -> Tuple[Dict[str, Any], Any]:
+        """Validate a DSL plan against ``schema``.
+
+        Returns the normalized plan and a ValidationReport.
+        """
+        return self._validator.validate_plan(plan, schema)
+
+    # ------------------------------------------------------------------
+    # SQL repair
+    # ------------------------------------------------------------------
+    def repair(self, sql: str, error: str, schema_context: str) -> Optional[str]:
+        """Attempt to repair ``sql`` given ``error`` and ``schema_context``.
+
+        Returns a fixed SQL string or ``None`` if repair fails.
+        """
+        err_type = self._classify_error(error)
+
+        system = {
+            "role": "system",
+            "content": (
+                "You are a SQL fixer. Return ONE corrected SQLite query only. "
+                "No markdown, no explanations."
+            ),
+        }
+        user = {
+            "role": "user",
+            "content": self._prompt_for(err_type, schema_context, sql, error),
+        }
+
+        try:
+            resp = LLMService.invoke(
+                model="gpt-3.5-turbo",
+                messages=[system, user],
+                temperature=0.0,
+                max_tokens=400,
+            )
+            record_openai_usage_from_response(resp)
+            fixed = resp.choices[0].message.content.strip()
+            if re.match(r"^\s*(select|with|update|delete|insert)\b", fixed, flags=re.I):
+                return fixed
+        except Exception:
+            pass
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _classify_error(self, msg: str) -> str:
+        m = msg.lower()
+        if "no such table" in m or "no such column" in m:
+            return "schema"
+        if "syntax error" in m:
+            return "syntax"
+        if "misuse of aggregate" in m or "group by" in m:
+            return "aggregate"
+        if "ambiguous column" in m:
+            return "ambiguous"
+        return "semantic"
+
+    def _prompt_for(self, err_type: str, schema_context: str, sql: str, error_msg: str) -> str:
+        common = f"""Schema:
+{schema_context}
+
+Previous SQL:
+{sql}
+
+Error:
+{error_msg}
+"""
+        if err_type == "schema":
+            checklist = (
+                "- Use only tables/columns present in the Schema.\n"
+                "- If a column is missing, pick the closest semantically relevant existing column.\n"
+                "- Preserve the original intent: keep aggregates, filters, and grouping.\n"
+            )
+        elif err_type == "aggregate":
+            checklist = (
+                "- If SELECT mixes aggregates and non-aggregates, add GROUP BY for all non-aggregated columns.\n"
+                "- Apply SUM/AVG/COUNT only to numeric columns.\n"
+            )
+        elif err_type == "ambiguous":
+            checklist = (
+                "- Qualify columns with table aliases.\n"
+                "- Join only on identically named key columns (e.g., *_id) that exist in both tables.\n"
+            )
+        elif err_type == "syntax":
+            checklist = (
+                "- Fix SQL syntax without changing intent.\n"
+                "- Ensure correct order/placement of WHERE, GROUP BY, ORDER BY, LIMIT.\n"
+            )
+        else:
+            checklist = (
+                "- For top-N, ensure ORDER BY a metric DESC and include LIMIT N.\n"
+                "- If empty results, relax strict equality to LIKE or >= where reasonable.\n"
+                "- If too many rows, add LIMIT 100 with ORDER BY a sensible metric.\n"
+            )
+
+        return (
+            f"{common}Fix the SQL using the checklist:\n\n"  # noqa: W503 - readability
+            f"Checklist:\n{checklist}"
+            "Return only ONE corrected SQLite query (no markdown, no prose)."
+        )


### PR DESCRIPTION
## Summary
- add ValidationEngine service that wraps SQLValidatorAgent and SQL repair logic
- route ReasoningAgent and SQLGeneratorAgent through the central validation engine
- update orchestrator and workflow to use new validation service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a58aa76c708331b44d7d9f81dc7082